### PR TITLE
Add support for DR Secondary and Performance Standby status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ or (optionally) standby state, as determined by the Vault health check endpoint.
 
 ### Rationale
 
-[HashiCorp Vault][vault] exposes a health check located at the [`/v1/sys/health`] endpoint, which can be used for
+[HashiCorp Vault][vault] exposes a health check located at the [`/v1/sys/health`] [endpoint][vault_health_endpoint], which can be used for
 determining whether a particular instance is ready for service - in an active or standby state - or whether the instance
 is sealed or uninitialized.
 
-HTTP `HEAD` requests to the health check endpoint return a status code representing the health of the target instance
-- by default, `200` for an active node, `429` for a standby node, and `500`-range codes for sealed or uninitialized
-Vaults.
+HTTP `HEAD` requests to the health check endpoint return a status code representing the health of the target instance:
+
+| Code | Description              |
+| ---- | ------------------------ |
+| 200  | Active Node              |
+| 429  | Standby Node             |
+| 472  | Active DR Secondary Node |
+| 473  | Standby Performance Node |
+| 501  | Uninitialized            |
+| 503  | Sealed                   |
+
 
 Unfortunately, the AWS [NLB][nlb] does not support HTTP health checks, instead supporting only TCP checks. While TCP
 checks can be pointed at a Vault server, they cannot determine the actual health of the instance, and fill the logs of
@@ -54,6 +62,7 @@ repository. `goreleaser` must be available on `PATH`.
 Feedback, issues and pull requests are welcome!
 
 [vault]: https://github.com/hashicorp/vault
+[vault_health_endpoint]: https://www.vaultproject.io/api/system/health
 [nlb]: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html
 [sockaddr]: https://github.com/hashicorp/go-sockaddr
 [duration]: https://golang.org/pkg/time/#ParseDuration

--- a/health_checker.go
+++ b/health_checker.go
@@ -13,11 +13,12 @@ import (
 )
 
 const (
-	vaultHealthCheckResponseActive        = 200
-	vaultHealthCheckResponseStandby       = 429
-	vaultHealthCheckResponseDRSecondary   = 472
-	vaultHealthCheckResponseSealed        = 503
-	vaultHealthCheckResponseUninitialized = 501
+	vaultHealthCheckResponseActive             = 200
+	vaultHealthCheckResponseStandby            = 429
+	vaultHealthCheckResponseDRSecondary        = 472
+	vaultHealthCheckResponsePerformanceStandby = 473
+	vaultHealthCheckResponseSealed             = 503
+	vaultHealthCheckResponseUninitialized      = 501
 )
 
 func statusCodeString(statusCode int64) string {
@@ -47,6 +48,7 @@ func newVaultHealthChecker(vaultBaseAddr string, checkInterval time.Duration,
 	query.Set("activecode", statusCodeString(vaultHealthCheckResponseActive))
 	query.Set("standbycode", statusCodeString(vaultHealthCheckResponseStandby))
 	query.Set("drsecondarycode", statusCodeString(vaultHealthCheckResponseDRSecondary))
+	query.Set("performancestandbycode", statusCodeString(vaultHealthCheckResponsePerformanceStandby))
 	query.Set("sealedcode", statusCodeString(vaultHealthCheckResponseSealed))
 	query.Set("uninitcode", statusCodeString(vaultHealthCheckResponseUninitialized))
 
@@ -92,6 +94,10 @@ func (hc *vaultHealthChecker) run() {
 			hc.sendStatus(vaultStatusActive)
 		case vaultHealthCheckResponseStandby:
 			hc.sendStatus(vaultStatusStandby)
+		case vaultHealthCheckResponseDRSecondary:
+			hc.sendStatus(vaultStatusDRSecondary)
+		case vaultHealthCheckResponsePerformanceStandby:
+			hc.sendStatus(vaultStatusPerformanceStandby)
 		default:
 			hc.sendStatus(vaultStatusUnhealthy)
 		}

--- a/tcp_listener.go
+++ b/tcp_listener.go
@@ -47,6 +47,12 @@ func (tl *tcpListener) run() {
 				tl.logger.Info("Vault Status: Unhealthy (Standby)")
 				shouldRun = false
 			}
+		case vaultStatusDRSecondary:
+			tl.logger.Info("Vault Status: Healthy (Active DR Secondary)")
+			shouldRun = true
+		case vaultStatusPerformanceStandby:
+			tl.logger.Info("Vault Status: Healthy (Performance Standby)")
+			shouldRun = true
 		case vaultStatusUnhealthy:
 			tl.logger.Info("Vault Status: Unhealthy")
 			shouldRun = false

--- a/vault_status.go
+++ b/vault_status.go
@@ -5,5 +5,7 @@ type vaultStatus uint8
 const (
 	vaultStatusActive vaultStatus = iota
 	vaultStatusStandby
+	vaultStatusDRSecondary
+	vaultStatusPerformanceStandby
 	vaultStatusUnhealthy
 )


### PR DESCRIPTION
Treat status codes 472 and 473 (DR Secondary Node and Performance Standby Node) as healthy responses.